### PR TITLE
Remove most of ai policy free promotions

### DIFF
--- a/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/AI/NewHandicap.lua
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/AI/NewHandicap.lua
@@ -1094,9 +1094,6 @@ function AIPromotion(iPlayer, iCity, iUnit, bGold, bFaith)
 			unit:Kill()
 		end
 	end
-	if unit~=nil and unit:GetID()~=nil then 
-		RemoveErrorPromotion(unit:GetOwner(), unit:GetID())
-	end
 end
 GameEvents.CityTrained.Add(AIPromotion)
 

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Combat/NewUnitsRules.lua
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Combat/NewUnitsRules.lua
@@ -114,13 +114,6 @@ function NewUnitCreationRules() ------------------------Human Player's units rul
 					then
 						unit:SetHasPromotion(OceanImpassableID, false);
 					end
-
-					-- Remove error promotion
-
-					if IsTimetoCheckPromotion then
-						RemoveErrorPromotion(playerID,unit:GetID())
-					end
-					
 					-- MOD Begin by CaptainCWB
 
 					-- Enterprise upgrade to become the most powerful carrier
@@ -677,18 +670,6 @@ function HeroicCarrierGenerate(playerID)
 end
 
 GameEvents.PlayerDoTurn.Add(HeroicCarrierGenerate)
-
-function NewUnitRemoveErrorPromotion( iPlayerID, iUnitID )
-	if( Players[ iPlayerID ] == nil or not Players[ iPlayerID ]:IsAlive()
-	or  Players[ iPlayerID ]:GetUnitByID( iUnitID ) == nil
-	or  Players[ iPlayerID ]:GetUnitByID( iUnitID ):IsDead()
-	or  Players[ iPlayerID ]:GetUnitByID( iUnitID ):IsDelayedDeath() )
-	then
-		return;
-	end
-	RemoveErrorPromotion(iPlayerID, iUnitID)
-end
-Events.SerialEventUnitCreated.Add(NewUnitRemoveErrorPromotion)
 -- MOD end by HMS
 
 -- MOD by CaptainCWB

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Utility/UtilityFunctions.lua
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Utility/UtilityFunctions.lua
@@ -533,7 +533,10 @@ function AIForceBuildAirEscortUnits(unitX, unitY, player)
 	end
 
 	local PlayerEra = player:GetCurrentEra()
-	local NewUnitEXP = PlayerEra * 20
+	local NewUnitEXP = PlayerEra * 15
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_DEFENSE_AIR)
 
@@ -566,6 +569,9 @@ function AIForceBuildNavalEscortUnits(unitX, unitY, player)
 
 	local PlayerEra = player:GetCurrentEra()
 	local NewUnitEXP = PlayerEra * 5
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ATTACK_SEA)
 
@@ -593,7 +599,10 @@ function AIForceBuildNavalHRUnits(unitX, unitY, player)
 	end
 
 	local PlayerEra = player:GetCurrentEra()
-	local NewUnitEXP = PlayerEra * 15
+	local NewUnitEXP = PlayerEra * 10
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ASSAULT_SEA)
 
@@ -628,7 +637,10 @@ function AIForceBuildNavalRangedUnits(unitX, unitY, player)
 	end
 
 	local PlayerEra = player:GetCurrentEra()
-	local NewUnitEXP = PlayerEra * 15
+	local NewUnitEXP = PlayerEra * 10
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ASSAULT_SEA)
 
@@ -658,6 +670,9 @@ function AIForceBuildInfantryUnits(unitX, unitY, player)
 
 	local PlayerEra = player:GetCurrentEra()
 	local NewUnitEXP = PlayerEra * 5
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ATTACK)
@@ -687,6 +702,9 @@ function AIForceBuildLandCounterUnits(unitX, unitY, player)
 
 	local PlayerEra = player:GetCurrentEra()
 	local NewUnitEXP = PlayerEra * 5
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ATTACK)
@@ -723,6 +741,9 @@ function AIForceBuildMobileUnits(unitX, unitY, player)
 
 	local PlayerEra = player:GetCurrentEra()
 	local NewUnitEXP = PlayerEra * 10
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_FAST_ATTACK)
 
@@ -757,7 +778,10 @@ function AIForceBuildLandHRUnits(unitX, unitY, player)
 	end
 
 	local PlayerEra = player:GetCurrentEra()
-	local NewUnitEXP = PlayerEra * 25
+	local NewUnitEXP = PlayerEra * 20
+	if player:GetCapitalCity() ~= nil then
+		NewUnitEXP = NewUnitEXP + player:GetCapitalCity():GetProductionExperience()
+	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_FAST_ATTACK)
 
@@ -791,6 +815,9 @@ function AIConscriptMilitiaUnits(unitX, unitY, player)
 	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_DEFENSE)
+	if player:GetCapitalCity() ~= nil then
+		NewUnit:SetExperience(player:GetCapitalCity():GetProductionExperience())
+	end
 	NewUnit:JumpToNearestValidPlot()
 
 	print("AI conscript Militia reporting! We fight to the last man!")
@@ -810,6 +837,9 @@ function AIConscriptMilitiaNavy(unitX, unitY, player)
 	end
 
 	local NewUnit = player:InitUnit(GameInfoTypes[sUnitType], unitX, unitY, UNITAI_ESCORT_SEA)
+	if player:GetCapitalCity() ~= nil then
+		NewUnit:SetExperience(player:GetCapitalCity():GetProductionExperience())
+	end
 	NewUnit:JumpToNearestValidPlot()
 
 	print("AI conscript Militia Navy boadt! We fight to the last boat!")
@@ -1131,291 +1161,7 @@ function CarrierRestore(iPlayerID, iUnitID, iCargoUnit)
 end
 
 -- MOD End   by CaptainCWB
-
--- MOD Begin by HMS
 function RemoveErrorPromotion(iPlayerID, iUnitID)
-	-- TODO(catgrep): remove this function
-	local player = Players[iPlayerID]
-	if player == nil then
-		print("No Player to RemovePromotion ")
-		return
-	end
-
-	if iUnitID == nil then
-		print("No unit to RemovePromotion")
-		return
-	end
-
-	if player:IsMinorCiv() or player:IsBarbarian() then
-		return
-	end
-
-	local unit = player:GetUnitByID(iUnitID)
-
-	if unit == nil then
-		print("No unit to RemovePromotion")
-		return
-	end
-
-
-	local unitX = unit:GetX()
-	local unitY = unit:GetY()
-
-	if unitX == nil or unitY == nil then
-		print("No Plot to Remove Promotion")
-		return
-	end
-	--Unit Type list
-	local RangedUnitID = GameInfo.UnitPromotions["PROMOTION_ARCHERY_COMBAT"].ID
-	local AntiAirID = GameInfo.UnitPromotions["PROMOTION_ANTI_AIR"].ID
-	local CitySiegeID = GameInfo.UnitPromotions["PROMOTION_CITY_SIEGE"].ID
-	local LandAOEUnitID = GameInfo.UnitPromotions["PROMOTION_SPLASH_DAMAGE"].ID
-	local FixedArtilleryID = GameInfo.UnitPromotions["PROMOTION_CITADEL_DEFENSE"].ID
-	local CounterMountedID = GameInfo.UnitPromotions["PROMOTION_ANTI_MOUNTED"].ID
-	local CounterTankID = GameInfo.UnitPromotions["PROMOTION_ANTI_TANK"].ID
-	local InfantryID = GameInfo.UnitPromotions["PROMOTION_INFANTRY_COMBAT"].ID
-	local GunpowderInfantryID = GameInfo.UnitPromotions["PROMOTION_GUNPOWDER_INFANTRY_COMBAT"].ID
-
-	local HitandRunID = GameInfo.UnitPromotions["PROMOTION_HITANDRUN"].ID
-	local HelicopterID = GameInfo.UnitPromotions["PROMOTION_HELI_ATTACK"].ID
-
-	local NavalCuiserID = GameInfo.UnitPromotions["PROMOTION_NAVAL_RANGED_CRUISER"].ID
-	local NavalHitandRunID = GameInfo.UnitPromotions["PROMOTION_NAVAL_HIT_AND_RUN"].ID
-	local NavalRangedID = GameInfo.UnitPromotions["PROMOTION_NAVAL_RANGED_SHIP"].ID
-	local SubmarineID = GameInfo.UnitPromotions["PROMOTION_SUBMARINE_COMBAT"].ID
-
-	local CapitalShipID = GameInfo.UnitPromotions["PROMOTION_NAVAL_CAPITAL_SHIP"].ID
-	local CarrierID = GameInfo.UnitPromotions["PROMOTION_CARRIER_UNIT"].ID
-
-	local SSBNID = GameInfo.UnitPromotions["PROMOTION_CARGO_IX"].ID
-
-	local BomberID = GameInfo.UnitPromotions["PROMOTION_STRATEGIC_BOMBER"].ID
-	local AirAttackID = GameInfo.UnitPromotions["PROMOTION_AIR_ATTACK"].ID
-	local LandBasedFighterID = GameInfo.UnitPromotions["PROMOTION_ANTI_AIR_II"].ID
-	local CarrierFighterID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER"].ID
-
-	--Promotion List
-	local InfantryShock1ID = GameInfo.UnitPromotions["PROMOTION_SHOCK_1"].ID
-	local InfantryShock2ID = GameInfo.UnitPromotions["PROMOTION_SHOCK_2"].ID
-	local InfantryShock3ID = GameInfo.UnitPromotions["PROMOTION_SHOCK_3"].ID
-	local Cover1ID = GameInfo.UnitPromotions["PROMOTION_COVER_1"].ID
-	local Cover2ID = GameInfo.UnitPromotions["PROMOTION_COVER_2"].ID
-	local Cover3ID = GameInfo.UnitPromotions["PROMOTION_COVER_3"].ID
-
-	local AntiMounted1ID = GameInfo.UnitPromotions["PROMOTION_FORMATION_1"].ID
-	local AntiMounted2ID = GameInfo.UnitPromotions["PROMOTION_FORMATION_2"].ID
-	local AntiTank1ID = GameInfo.UnitPromotions["PROMOTION_AMBUSH_1"].ID
-	local AntiTank2ID = GameInfo.UnitPromotions["PROMOTION_AMBUSH_2"].ID
-	local CQBCombat1ID = GameInfo.UnitPromotions["PROMOTION_CQB_COMBAT_1"].ID
-	local CQBCombat2ID = GameInfo.UnitPromotions["PROMOTION_CQB_COMBAT_2"].ID
-
-	local BlitzID = GameInfo.UnitPromotions["PROMOTION_BLITZ"].ID
-	local LogisticsID = GameInfo.UnitPromotions["PROMOTION_LOGISTICS"].ID
-
-	local CollDamageLV1ID = GameInfo.UnitPromotions["PROMOTION_COLLATERAL_DAMAGE_1"].ID
-	local CollDamageLV2ID = GameInfo.UnitPromotions["PROMOTION_COLLATERAL_DAMAGE_2"].ID
-	-- local CollDamageLV3ID = GameInfo.UnitPromotions["PROMOTION_COLLATERAL_DAMAGE_3"].ID
-
-	local SiegeLV1ID = GameInfo.UnitPromotions["PROMOTION_VOLLEY_1"].ID
-	local SiegeLV2ID = GameInfo.UnitPromotions["PROMOTION_VOLLEY_2"].ID
-
-	local Barrage1ID = GameInfo.UnitPromotions["PROMOTION_BARRAGE_1"].ID
-	local Barrage2ID = GameInfo.UnitPromotions["PROMOTION_BARRAGE_2"].ID
-	local Barrage3ID = GameInfo.UnitPromotions["PROMOTION_BARRAGE_3"].ID
-	local LongBowManUnitID = GameInfo.UnitPromotions["PROMOTION_RANGE_SPECIAL"].ID
-
-	local Accuracy1ID = GameInfo.UnitPromotions["PROMOTION_ACCURACY_1"].ID
-	local Accuracy2ID = GameInfo.UnitPromotions["PROMOTION_ACCURACY_2"].ID
-
-	local FlankGun1ID = GameInfo.UnitPromotions["PROMOTION_FLANK_GUN_1"].ID
-	local FlankGun2ID = GameInfo.UnitPromotions["PROMOTION_FLANK_GUN_2"].ID
-
-	local Sunder1ID = GameInfo.UnitPromotions["PROMOTION_SUNDER_1"].ID
-	local Sunder2ID = GameInfo.UnitPromotions["PROMOTION_SUNDER_2"].ID
-	-- local Sunder3ID = GameInfo.UnitPromotions["PROMOTION_SUNDER_3"].ID
-
-	local AntiNaval1ID = GameInfo.UnitPromotions["PROMOTION_FAE_ROCKET_1"].ID
-	local AntiNaval2ID = GameInfo.UnitPromotions["PROMOTION_FAE_ROCKET_2"].ID
-	local AOEAttack1ID = GameInfo.UnitPromotions["PROMOTION_CLUSTER_ROCKET_1"].ID
-	local AOEAttack2ID = GameInfo.UnitPromotions["PROMOTION_CLUSTER_ROCKET_2"].ID
-	local CapitalShipArmor1ID = GameInfo.UnitPromotions["PROMOTION_ARMOR_BATTLESHIP_1"].ID
-	local CapitalShipArmor2ID = GameInfo.UnitPromotions["PROMOTION_ARMOR_BATTLESHIP_2"].ID
-
-	local NapalmBomb1ID = GameInfo.UnitPromotions["PROMOTION_NAPALMBOMB_1"].ID
-	local NapalmBomb2ID = GameInfo.UnitPromotions["PROMOTION_NAPALMBOMB_2"].ID
-	local NapalmBomb3ID = GameInfo.UnitPromotions["PROMOTION_NAPALMBOMB_3"].ID
-	local DestroySupply1ID = GameInfo.UnitPromotions["PROMOTION_DESTROY_SUPPLY_1"].ID
-	local DestroySupply2ID = GameInfo.UnitPromotions["PROMOTION_DESTROY_SUPPLY_2"].ID
-	local AirSiege1ID = GameInfo.UnitPromotions["PROMOTION_AIR_SIEGE_1"].ID
-	local AirSiege2ID = GameInfo.UnitPromotions["PROMOTION_AIR_SIEGE_2"].ID
-	local AirSiege3ID = GameInfo.UnitPromotions["PROMOTION_AIR_SIEGE_3"].ID
-
-	local AirBomb1ID = GameInfo.UnitPromotions["PROMOTION_AIR_BOMBARDMENT_1"].ID
-	local AirBomb2ID = GameInfo.UnitPromotions["PROMOTION_AIR_BOMBARDMENT_2"].ID
-	local AirBomb3ID = GameInfo.UnitPromotions["PROMOTION_AIR_BOMBARDMENT_3"].ID
-	local AirTarget1ID = GameInfo.UnitPromotions["PROMOTION_AIR_TARGETING_1"].ID
-	local AirTarget2ID = GameInfo.UnitPromotions["PROMOTION_AIR_TARGETING_2"].ID
-	local AirTarget3ID = GameInfo.UnitPromotions["PROMOTION_AIR_TARGETING_3"].ID
-
-	local DogFight1ID = GameInfo.UnitPromotions["PROMOTION_DOGFIGHTING_1"].ID
-	local DogFight2ID = GameInfo.UnitPromotions["PROMOTION_DOGFIGHTING_2"].ID
-	local DogFight3ID = GameInfo.UnitPromotions["PROMOTION_DOGFIGHTING_3"].ID
-	local Intercept1ID = GameInfo.UnitPromotions["PROMOTION_INTERCEPTION_1"].ID
-	local Intercept2ID = GameInfo.UnitPromotions["PROMOTION_INTERCEPTION_2"].ID
-	local Intercept3ID = GameInfo.UnitPromotions["PROMOTION_INTERCEPTION_3"].ID
-
-	local AIHitandRunID = GameInfo.UnitPromotions["PROMOTION_RANGE_REDUCE"].ID
-	local AIRangeID = GameInfo.UnitPromotions["PROMOTION_RANGE"].ID
-
-	local AISPForceID = GameInfo.UnitPromotions["PROMOTION_SPECIAL_FORCES_COMBAT"].ID
-
-	local SetUpID = GameInfo.UnitPromotions["PROMOTION_MUST_SET_UP"].ID
-
-	local MilitiaUnitID = GameInfo.UnitPromotions["PROMOTION_MILITIA_COMBAT"].ID
-
-	local CarrierSupply1ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_SUPPLY_1"].ID
-	local CarrierSupply2ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_SUPPLY_2"].ID
-	local CarrierSupply3ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_SUPPLY_3"].ID
-	local CarrierAntiAir1ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_AIRFIGHT_1"].ID
-	local CarrierAntiAir2ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_AIRFIGHT_2"].ID
-	local CarrierAttack1ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_ATTACK_1"].ID
-	local CarrierAttack2ID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_ATTACK_2"].ID
-	local DestroySupply_CarrierID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_SIEGE_1"].ID
-	local AirTarget_CarrierID = GameInfo.UnitPromotions["PROMOTION_CARRIER_FIGHTER_SIEGE_2"].ID
-
-	local CorpsID = GameInfo.UnitPromotions["PROMOTION_CORPS_1"].ID;
-	local ArmeeID = GameInfo.UnitPromotions["PROMOTION_CORPS_2"].ID;
-
-	-- Units with formation(anti-mounted) auto upgrade to Ambush(anti-tank). -- Longbowman and Camelarcher also update.
-	if unit:IsHasPromotion(CounterTankID) or unit:IsHasPromotion(HelicopterID) or unit:IsHasPromotion(AntiAirID) then
-		if unit:IsHasPromotion(AntiMounted1ID) then
-			unit:SetHasPromotion(AntiMounted1ID, false);
-			unit:SetHasPromotion(AntiTank1ID, true);
-		end
-		if unit:IsHasPromotion(AntiMounted2ID) then
-			unit:SetHasPromotion(AntiMounted2ID, false);
-			unit:SetHasPromotion(AntiTank2ID, true);
-		end
-	end
-
-	if unit:IsHasPromotion(CounterMountedID) or unit:IsHasPromotion(CounterTankID) then
-		unit:SetHasPromotion(InfantryShock1ID, false)
-		unit:SetHasPromotion(InfantryShock2ID, false)
-		unit:SetHasPromotion(InfantryShock3ID, false)
-		unit:SetHasPromotion(Cover1ID, false)
-		unit:SetHasPromotion(Cover2ID, false)
-		unit:SetHasPromotion(Cover3ID, false)
-		unit:SetHasPromotion(BlitzMeleeID, false)
-	end
-	if unit:IsHasPromotion(InfantryID) or unit:IsHasPromotion(GunpowderInfantryID) then
-		unit:SetHasPromotion(AntiTank1ID, false)
-		unit:SetHasPromotion(AntiTank2ID, false)
-		unit:SetHasPromotion(AntiMounted1ID, false)
-		unit:SetHasPromotion(AntiMounted2ID, false)
-		unit:SetHasPromotion(CQBCombat1ID, false)
-		unit:SetHasPromotion(CQBCombat2ID, false)
-	end
-	if unit:IsHasPromotion(RangedUnitID) then
-		unit:SetHasPromotion(SiegeLV1ID, false)
-		unit:SetHasPromotion(SiegeLV2ID, false)
-		unit:SetHasPromotion(CollDamageLV1ID, false)
-		unit:SetHasPromotion(CollDamageLV2ID, false)
-		-- unit:SetHasPromotion(CollDamageLV3ID,false)
-		unit:SetHasPromotion(BlitzID, false)
-	end
-	if unit:IsHasPromotion(CitySiegeID) then
-		unit:SetHasPromotion(FlankGun1ID, false)
-		unit:SetHasPromotion(FlankGun2ID, false)
-		unit:SetHasPromotion(Accuracy1ID, false)
-		unit:SetHasPromotion(Accuracy2ID, false)
-		unit:SetHasPromotion(Barrage1ID, false)
-		unit:SetHasPromotion(Barrage2ID, false)
-		unit:SetHasPromotion(Barrage3ID, false)
-		unit:SetHasPromotion(BlitzID, false)
-		unit:SetHasPromotion(LongBowManUnitID, false)
-	end
-	if unit:IsHasPromotion(FixedArtilleryID) then
-		unit:SetHasPromotion(AntiNaval1ID, false)
-		unit:SetHasPromotion(AntiNaval2ID, false)
-		unit:SetHasPromotion(AOEAttack1ID, false)
-		unit:SetHasPromotion(AOEAttack2ID, false)
-	end
-	if unit:IsHasPromotion(NavalRangedID) or unit:IsHasPromotion(NavalCuiserID) then
-		unit:SetHasPromotion(CapitalShipArmor1ID, false)
-		unit:SetHasPromotion(CapitalShipArmor2ID, false)
-		unit:SetHasPromotion(AOEAttack1ID, false)
-		unit:SetHasPromotion(AOEAttack2ID, false)
-		unit:SetHasPromotion(IndirectFireID, false)
-		unit:SetHasPromotion(BlitzID, false)
-	end
-	if unit:IsHasPromotion(CapitalShipID) then
-		unit:SetHasPromotion(FlankGun1ID, false)
-		unit:SetHasPromotion(FlankGun2ID, false)
-		unit:SetHasPromotion(Sunder1ID, false)
-		unit:SetHasPromotion(Sunder2ID, false)
-		-- unit:SetHasPromotion(Sunder3ID,false)
-		unit:SetHasPromotion(CollDamageLV1ID, false)
-		unit:SetHasPromotion(CollDamageLV2ID, false)
-		-- unit:SetHasPromotion(CollDamageLV3ID,false)
-		unit:SetHasPromotion(BlitzID, false)
-		unit:SetHasPromotion(LogisticsID, false)
-	end
-	if unit:IsHasPromotion(AirAttackID) then
-		unit:SetHasPromotion(DestroySupply1ID, false)
-		unit:SetHasPromotion(DestroySupply2ID, false)
-		unit:SetHasPromotion(AirSiege1ID, false)
-		unit:SetHasPromotion(AirSiege2ID, false)
-		unit:SetHasPromotion(AirSiege3ID, false)
-		unit:SetHasPromotion(NapalmBomb1ID, false)
-		unit:SetHasPromotion(NapalmBomb2ID, false)
-		unit:SetHasPromotion(NapalmBomb3ID, false)
-	end
-	if unit:IsHasPromotion(BomberID) then
-		unit:SetHasPromotion(AirBomb1ID, false)
-		unit:SetHasPromotion(AirBomb2ID, false)
-		unit:SetHasPromotion(AirBomb3ID, false)
-		unit:SetHasPromotion(AirTarget1ID, false)
-		unit:SetHasPromotion(AirTarget2ID, false)
-		unit:SetHasPromotion(AirTarget3ID, false)
-		unit:SetHasPromotion(BlitzID, false)
-		unit:SetHasPromotion(LogisticsID, false)
-	end
-	if unit:IsHasPromotion(CarrierFighterID) then
-		unit:SetHasPromotion(DogFight1ID, false)
-		unit:SetHasPromotion(DogFight2ID, false)
-		unit:SetHasPromotion(DogFight3ID, false)
-		unit:SetHasPromotion(Intercept1ID, false)
-		unit:SetHasPromotion(Intercept2ID, false)
-		unit:SetHasPromotion(Intercept3ID, false)
-	end
-	if unit:IsHasPromotion(LandBasedFighterID) or unit:IsHasPromotion(BomberID) or unit:IsHasPromotion(AirAttackID) then
-		unit:SetHasPromotion(CarrierAntiAir1ID, false)
-		unit:SetHasPromotion(CarrierAntiAir2ID, false)
-		unit:SetHasPromotion(CarrierSupply1ID, false)
-		unit:SetHasPromotion(CarrierSupply2ID, false)
-		unit:SetHasPromotion(CarrierSupply3ID, false)
-		unit:SetHasPromotion(DestroySupply_CarrierID, false)
-		unit:SetHasPromotion(AirTarget_CarrierID, false)
-		unit:SetHasPromotion(CarrierAttack1ID, false)
-		unit:SetHasPromotion(CarrierAttack2ID, false)
-	end
-
-	-- MOD Begin by CaptainCWB
-	-- Remove Corps Promotions in Record Mode without Corps Mode
-	if (PreGame.GetGameOption("GAMEOPTION_SP_RECORD_MODE") == 1
-			and PreGame.GetGameOption("GAMEOPTION_SP_CORPS_MODE_DISABLE") == 1)
-		or unit:GetDomainType() ~= DomainTypes.DOMAIN_LAND
-	then
-		if unit:IsHasPromotion(CorpsID) then
-			unit:SetHasPromotion(CorpsID, false);
-		end
-		if unit:IsHasPromotion(ArmeeID) then
-			unit:SetHasPromotion(ArmeeID, false);
-		end
-	end
-	-- MOD End   by CaptainCWB
+	-- keep for compatibility
 end
-
--- MOD end by HMS
-
 print("UtilityFunctions Check Pass!")

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/AI/AIBonus.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/AI/AIBonus.xml
@@ -11,6 +11,7 @@
 			<SettlerProductionModifier>300</SettlerProductionModifier>
 			<CityGrowthMod>10</CityGrowthMod>
 			<PlotCultureExponentModifier>-15</PlotCultureExponentModifier>
+			<FreeExperience>10</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_MEDIEVAL</Type>
@@ -18,21 +19,22 @@
 			<CityGrowthMod>15</CityGrowthMod>
 			<IncludesOneShotFreeUnits>true</IncludesOneShotFreeUnits>
 			<UnhappinessMod>-5</UnhappinessMod>
+			<FreeExperience>15</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_RENAISSANCE</Type>
 			<Description>TXT_KEY_POLICY_PHILANTHROPY</Description>
 			<CatchSpiesModifier>-30</CatchSpiesModifier>
 			<UnhappinessMod>-5</UnhappinessMod>
-			<FreeExperience>15</FreeExperience>
 			<CityGrowthMod>15</CityGrowthMod>
+			<FreeExperience>25</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_INDUSTRY</Type>
 			<Description>TXT_KEY_POLICY_PHILANTHROPY</Description>	
 			<CatchSpiesModifier>-60</CatchSpiesModifier>
 			<UnhappinessMod>-10</UnhappinessMod>
-			<FreeExperience>15</FreeExperience>
+			<FreeExperience>30</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_MODERN</Type>
@@ -40,8 +42,8 @@
 			<MinorGoldFriendshipMod>25</MinorGoldFriendshipMod>
 			<UnitGoldMaintenanceMod>-25</UnitGoldMaintenanceMod>
 			<ThemingBonusMultiplier>200</ThemingBonusMultiplier>
-			<FreeExperience>30</FreeExperience>
 			<UnhappinessMod>-20</UnhappinessMod>
+			<FreeExperience>30</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_WORLDWAR</Type>
@@ -51,6 +53,7 @@
 			<AfraidMinorPerTurnInfluence>100</AfraidMinorPerTurnInfluence>
 			<ThemingBonusMultiplier>300</ThemingBonusMultiplier>
 			<UnhappinessMod>-20</UnhappinessMod>
+			<FreeExperience>45</FreeExperience>
 		</Row>
 		<Row>
 			<Type>POLICY_AI_ATOMIC</Type>
@@ -59,6 +62,7 @@
 			<ProtectedMinorPerTurnInfluence>200</ProtectedMinorPerTurnInfluence>
 			<AfraidMinorPerTurnInfluence>200</AfraidMinorPerTurnInfluence>
 			<ThemingBonusMultiplier>600</ThemingBonusMultiplier>
+			<FreeExperience>45</FreeExperience>
 		</Row>
 
 
@@ -245,7 +249,6 @@
 	
 	
 	<Policy_FreePromotions>
-		
 		<Row>
 			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
 			<PromotionType>PROMOTION_MARCH</PromotionType>
@@ -270,464 +273,6 @@
 			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
 			<PromotionType>PROMOTION_FASTER_HEAL</PromotionType>
 		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_FAE_ROCKET_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_FAE_ROCKET_2</PromotionType>
-		</Row>
-	
-
-
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_RANGE</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_BLITZ</PromotionType>
-		</Row>
-		<!--<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_LOGISTICS</PromotionType>
-		</Row>-->
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_GUERRILLA_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_MEDIC</PromotionType>
-		</Row>
-
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_GUERRILLA_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_MEDIC_II</PromotionType>
-		</Row>
-
-
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_SP_FORCE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_SP_FORCE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_SP_FORCE_3</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_SHOCK_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_SHOCK_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_SHOCK_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_COVER_1</PromotionType>
-		</Row>
-		<Row> 
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_COVER_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_COVER_3</PromotionType>
-		</Row>
-		
-
-
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_SUNDER_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_SUNDER_2</PromotionType>
-		</Row>
-		<!--
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_SUNDER_3</PromotionType>
-		</Row>
-		-->
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_HUNTDOWN_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_HUNTDOWN_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_HUNTDOWN_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_CQB_COMBAT_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_CQB_COMBAT_2</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_FORMATION_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_FORMATION_2</PromotionType>
-		</Row>
-		
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_AMBUSH_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AMBUSH_2</PromotionType>
-		</Row>
-
-
-
-
-		 <Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_HEAVY_SHOCK_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_HEAVY_SHOCK_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_HEAVY_SHOCK_3</PromotionType>
-		</Row>	
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_CHARGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_CHARGE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CHARGE_3</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_ACCURACY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_ACCURACY_2</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_3</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_FLANK_GUN_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_FLANK_GUN_2</PromotionType>
-		</Row>
-	
-
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_VOLLEY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_VOLLEY_2</PromotionType>
-		</Row>
-		
-
-
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_CLUSTER_ROCKET_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_CLUSTER_ROCKET_2</PromotionType>
-		</Row>
-
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_ARMOR_BATTLESHIP_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_ARMOR_BATTLESHIP_2</PromotionType>
-		</Row>
-
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_BOARDING_PARTY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_BOARDING_PARTY_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_BOARDING_PARTY_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_SCOUTING_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_SCOUTING_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_SCOUTING_3</PromotionType>
-		</Row>
-	
-
-
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
-			<PromotionType>PROMOTION_COLLATERAL_DAMAGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_INDUSTRY</PolicyType>
-			<PromotionType>PROMOTION_COLLATERAL_DAMAGE_2</PromotionType>
-		</Row>
-		<!--
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_COLLATERAL_DAMAGE_3</PromotionType>
-		</Row>
-		-->
-
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_SUPPLY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_SUPPLY_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_SUPPLY_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_ATTACK_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_ATTACK_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_SIEGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_SIEGE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_SORTIE</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_ANTI_AIR_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_CARRIER_FIGHTER_ANTI_AIR_2</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_INTERCEPTION_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_INTERCEPTION_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_INTERCEPTION_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_DOGFIGHTING_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_DOGFIGHTING_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_DOGFIGHTING_3</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_AIR_BOMBARDMENT_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_BOMBARDMENT_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_BOMBARDMENT_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_MODERN</PolicyType>
-			<PromotionType>PROMOTION_AIR_TARGETING_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_TARGETING_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_TARGETING_3</PromotionType>
-		</Row>
-
-		
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_NAPALMBOMB_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_NAPALMBOMB_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_NAPALMBOMB_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_SIEGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_AIR_SIEGE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_AIR_SIEGE_3</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_DESTROY_SUPPLY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_WORLDWAR</PolicyType>
-			<PromotionType>PROMOTION_DESTROY_SUPPLY_2</PromotionType>
-		</Row>
-		<!--Test!
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_CQB_COMBAT_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_AIR_BOMBARDMENT_1</PromotionType>
-		</Row>
-				<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_2</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_BARRAGE_3</PromotionType>
-		</Row>
-
-
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_FLANK_GUN_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_AI_ATOMIC</PolicyType>
-			<PromotionType>PROMOTION_FLANK_GUN_2</PromotionType>
-		</Row>
-	
-
-
-
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_VOLLEY_1</PromotionType>
-		</Row>
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_VOLLEY_2</PromotionType>
-		</Row>
-		
-		<Row>
-			<PolicyType>POLICY_ELITE_FORCES</PolicyType>
-			<PromotionType>PROMOTION_AIR_SIEGE_1</PromotionType>
-		</Row>-->
-		
 	</Policy_FreePromotions>
 	
 	

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
@@ -15401,7 +15401,8 @@
 
 		<Replace Tag="TXT_KEY_PROMOTION_GREAT_GENERAL_HELP" >
 			<Text>[ICON_BULLET]Improve [ICON_STRENGTH] Combat Strength to all [COLOR_POSITIVE_TEXT]land Units[ENDCOLOR] within 2 tiles.
-			[NEWLINE][ICON_BULLET]Can [COLOR_POSITIVE_TEXT]Encourage[ENDCOLOR] an unit to remove all its Debuff conditions by consuming all [ICON_MOVES] MPs of the Great General.</Text>
+			[NEWLINE][ICON_BULLET]Can [COLOR_POSITIVE_TEXT]Encourage[ENDCOLOR] an unit to remove all its Debuff conditions by consuming all [ICON_MOVES] MPs of the Great General.
+			[NEWLINE][ICON_BULLET]Immune to Collateral Damage and Splash Damage.</Text>
 		</Replace>
 		
 		

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
@@ -13387,7 +13387,7 @@
 		</Replace>-->
 
 		<Replace Tag="TXT_KEY_PROMOTION_GREAT_GENERAL_HELP" >
-			<Text>提升邻近两格的陆军单位的战斗效率。[NEWLINE]能够消耗一回合移动力来移除一个陆军单位的所有负面状态。</Text>
+			<Text>提升邻近两格的陆军单位的战斗效率。[NEWLINE]能够消耗一回合移动力来移除一个陆军单位的所有负面状态。[NEWLINE]免疫溅射和穿透伤害。</Text>
 		</Replace>
 
 		<Replace Tag="TXT_KEY_PROMOTION_GREAT_ADMIRAL_HELP" >

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
@@ -13200,7 +13200,7 @@
 		</Replace>-->		
 
 		<Replace Tag="TXT_KEY_PROMOTION_GREAT_GENERAL_HELP" >
-			<Text>提升鄰近兩格的陸軍單位的戰鬥效率。[NEWLINE]能夠消耗一回合移動力來移除一個陸軍單位的所有負面狀態。</Text>
+			<Text>提升鄰近兩格的陸軍單位的戰鬥效率。[NEWLINE]能夠消耗一回合移動力來移除一個陸軍單位的所有負面狀態。[NEWLINE]免疫濺射和穿透傷害。</Text>
 		</Replace>
 		
 		<Replace Tag="TXT_KEY_PROMOTION_GREAT_ADMIRAL_HELP" >

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/UnitPromotions.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/UnitPromotions.xml
@@ -4584,6 +4584,8 @@
 			<SameTileHealChange>15</SameTileHealChange>
 			<EnemyHealChange>25</EnemyHealChange>
 			<NeutralHealChange>25</NeutralHealChange>
+			<CollateralDamageImmune>true</CollateralDamageImmune>
+			<SplashDamageImmune>true</SplashDamageImmune>
 		</Row>
 
 		<Row>
@@ -4599,6 +4601,8 @@
 			<PediaEntry>TXT_KEY_PEDIA_PROMOTION_GREAT_GENERAL</PediaEntry>
 			<EnemyHealChange>25</EnemyHealChange>
 			<NeutralHealChange>25</NeutralHealChange>
+			<CollateralDamageImmune>true</CollateralDamageImmune>
+			<SplashDamageImmune>true</SplashDamageImmune>
 		</Row>
 
 	</UnitPromotions>
@@ -6408,6 +6412,7 @@
 			<PediaType>PEDIA_ATTRIBUTES</PediaType>
 			<PediaEntry>TXT_KEY_PROMOTION_ANTI_COLLATERAL</PediaEntry>
 			<CannotBeChosen>true</CannotBeChosen>
+			<CollateralDamageImmune>true</CollateralDamageImmune>
 		</Row>
 		<Row>
 			<Type>PROMOTION_ANTI_SPLASH</Type>
@@ -6419,6 +6424,7 @@
 			<PediaType>PEDIA_ATTRIBUTES</PediaType>
 			<PediaEntry>TXT_KEY_PROMOTION_ANTI_SPLASH</PediaEntry>
 			<CannotBeChosen>true</CannotBeChosen>
+			<SplashDamageImmune>true</SplashDamageImmune>
 		</Row>
 
 		<Row>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Elite.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Elite.xml
@@ -1360,6 +1360,22 @@
 			<UnitType>UNIT_ELITE_SNIPER</UnitType>
 			<PromotionType>PROMOTION_SECOND_ATTACK</PromotionType>
 		</Row>
+		<Row>
+			<UnitType>UNIT_ELITE_SNIPER</UnitType>
+			<PromotionType>PROMOTION_SUNDER_1</PromotionType>
+		</Row>
+		<Row>
+			<UnitType>UNIT_ELITE_SNIPER</UnitType>
+			<PromotionType>PROMOTION_SUNDER_2</PromotionType>
+		</Row>
+		<Row>
+			<UnitType>UNIT_ELITE_SNIPER</UnitType>
+			<PromotionType>PROMOTION_ANTI_COLLATERAL</PromotionType>
+		</Row>
+		<Row>
+			<UnitType>UNIT_ELITE_SNIPER</UnitType>
+			<PromotionType>PROMOTION_ANTI_SPLASH</PromotionType>
+		</Row>
 
 
 


### PR DESCRIPTION
1.移除了绝大多数的AI政策免费晋升（即本身可选的晋升），并给相应晋升增加免费经验
2.移除检测非法晋升的代码
3.给ai刷兵的经验增加了AI首都经验
4.大军晋升增加穿透溅射免疫
5.精英狙击手新增破阵1-2级、穿透溅射免疫