### PR TITLE
changes: Misc of V10.10

### DIFF
--- a/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Economy/NewBuildingRule.lua
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/Lua/Economy/NewBuildingRule.lua
@@ -195,7 +195,7 @@ if bIsAllUBActive or Game.IsCivEverActive(GameInfoTypes.CIVILIZATION_ZULU) then
 		end
 
 		local pUnit = pPlayer:GetUnitByID(iUnit)
-		if pUnit == nil then return end
+		if pUnit == nil or pUnit:GetUnitCombatType() == GameInfoTypes["UNITCOMBAT_RECON"] then return end
 
 		local iBonus = pPlayer:GetCurrentEra() / 2 + 1;
 		iBonus = math.floor(iBonus * iNumIzako);

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/AI/AIBonus.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/AI/AIBonus.xml
@@ -251,12 +251,12 @@
 
 	<Policy_FreeUnitClasses>
 		<Row>
-			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
+			<PolicyType>POLICY_AI_CLASSICAL</PolicyType>
 			<UnitClassType>UNITCLASS_SETTLER</UnitClassType>
 			<Count>1</Count>
 		</Row>
 		<Row>
-			<PolicyType>POLICY_AI_RENAISSANCE</PolicyType>
+			<PolicyType>POLICY_AI_MEDIEVAL</PolicyType>
 			<UnitClassType>UNITCLASS_SETTLER</UnitClassType>
 			<Count>1</Count>
 		</Row>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Buildings/BuildingsEffects.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Buildings/BuildingsEffects.xml
@@ -1669,11 +1669,6 @@
 			<YieldType>YIELD_SCIENCE</YieldType>
 			<Yield>3</Yield>
 		</Row>
-		<Row>
-			<BuildingType>BUILDING_WAT</BuildingType>
-			<YieldType>YIELD_FAITH</YieldType>
-			<Yield>3</Yield>
-		</Row>
 
 
 		<Row>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Civilizations/Traits.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Civilizations/Traits.xml
@@ -45,7 +45,7 @@
 			<ShortDescription>TXT_KEY_TRAIT_ART_OF_WAR_SHORT</ShortDescription>
 			<!--<GreatGeneralRateModifier>50</GreatGeneralRateModifier>-->
 			<GoldenAgeResearchTotalCostModifier>0</GoldenAgeResearchTotalCostModifier>
-			<GoldenAgeResearchCityCountCostModifier>-80</GoldenAgeResearchCityCountCostModifier>
+			<GoldenAgeResearchCityCountCostModifier>-50</GoldenAgeResearchCityCountCostModifier>
 			<GoldenAgeGrowThresholdModifier>-20</GoldenAgeGrowThresholdModifier>
 		</Row>
 		
@@ -132,7 +132,7 @@
 			<Description>TXT_KEY_TRAIT_BUFFALO_HORNS</Description>
 			<ShortDescription>TXT_KEY_TRAIT_BUFFALO_HORNS_SHORT</ShortDescription>
 			<LevelExperienceModifier>-50</LevelExperienceModifier>
-			<LandUnitMaintenanceModifier>-15</LandUnitMaintenanceModifier>
+			<NoDoDeficit>true</NoDoDeficit>
 		</Row>
 		
 		
@@ -460,13 +460,6 @@
 			<YieldType>YIELD_PRODUCTION</YieldType>
 			<Yield>1</Yield>
 		</Row>
-		<Row>
-			<TraitType>TRAIT_AMPHIB_WARLORD</TraitType>
-			<ImprovementType>IMPROVEMENT_TRADING_POST</ImprovementType>
-			<YieldType>YIELD_GOLD</YieldType>
-			<Yield>1</Yield>
-		</Row>
-
 
 		<Row>
 			<TraitType>TRAIT_CONVERTS_SEA_BARBARIANS</TraitType>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/GameInfo/SpecialistsRules.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/GameInfo/SpecialistsRules.xml
@@ -171,7 +171,7 @@
 			<NukeImmune>true</NukeImmune>
 			<PortraitIndex>0</PortraitIndex>
 			<IconAtlas>BUILDING_SWEDEN_NOBEL_PRIZE_ATLAS</IconAtlas>
-            <InstantResearchFromFriendlyGreatScientist>15</InstantResearchFromFriendlyGreatScientist>
+            <InstantResearchFromFriendlyGreatScientist>20</InstantResearchFromFriendlyGreatScientist>
 		</Row>
 		<Row>
 			<Type>BUILDING_SPECIALISTS_SCIENTIFIC_LV3</Type>
@@ -359,7 +359,7 @@
 		</Row>
 		<Row>
 			<BuildingType>BUILDING_SWEDEN_NOBEL_PRIZE</BuildingType>
-			<BuildingClassType>BUILDINGCLASS_CITY_SIZE_LARGE</BuildingClassType>
+			<BuildingClassType>BUILDINGCLASS_CITY_SIZE_XL</BuildingClassType>
 		</Row>
 		<Row>
 			<BuildingType>BUILDING_SPECIALISTS_SCIENTIFIC_LV3</BuildingType>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
@@ -7394,7 +7394,7 @@
 			<Text>
 				[COLOR_POSITIVE_TEXT]Tradition[ENDCOLOR] is best for "tall" empires.
 				[NEWLINE][NEWLINE]Opening Effect:
-				[NEWLINE][ICON_BULLET]+3 [ICON_CULTURE] and +3 [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital.
+				[NEWLINE][ICON_BULLET]+3 [ICON_CULTURE] Culture and +3 [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital.
 				[NEWLINE][ICON_BULLET]International trade routes from your Capital City +3 range and +3 [ICON_GOLD] Gold.
 				[NEWLINE][ICON_BULLET]-25% [ICON_CULTURE] Culture Exponent cost for acquiring new plots in all cities.
 				[NEWLINE][ICON_BULLET]Wonder Unlocked: Hanging Gardens.
@@ -7408,7 +7408,7 @@
 			<Text>
 				[COLOR_POSITIVE_TEXT]Aristocracy[ENDCOLOR]
 				[NEWLINE][ICON_BULLET]New Cities start with an extra 1 [ICON_CITIZEN] Citizen. (But one Settler Unit still equals one Population)
-				[NEWLINE][ICON_BULLET]100% [ICON_FOOD] is carried over after a new [ICON_CITIZEN] Citizen is born for every Town (Cities with a [ICON_CITIZEN] Population less than 6). It won't be effective instantly but after the next new [ICON_CITIZEN] Citizen is born.
+				[NEWLINE][ICON_BULLET]100% [ICON_FOOD] Food is carried over after a new [ICON_CITIZEN] Citizen is born for every Town (Cities with a [ICON_CITIZEN] Population less than 6). It won't be effective instantly but after the next new [ICON_CITIZEN] Citizen is born.
 				[NEWLINE][ICON_BULLET]The accumulation of Food Kept and the accumulation of [ICON_FOOD] Food in all city immediately filled up.
 			</Text>
 		</Replace>
@@ -18297,5 +18297,21 @@
 		<Row Tag="TXT_KEY_MILITARY_PROMISE">
 			<Text>Promise withdraw Military</Text>
 		</Row>
+
+		<Replace Tag="TXT_KEY_FOODMOD_PLAYER">
+			<Text>[NEWLINE][ICON_BULLET]Empire Modifier (Difference): {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_CAPITAL">
+			<Text>[NEWLINE][ICON_BULLET][ICON_CAPITAL] Capital Modifier (Difference): {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_RELIGION">
+			<Text>[NEWLINE][ICON_BULLET]Religious Belief Modifier (Difference): {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_UNHAPPY">
+			<Text>[NEWLINE][ICON_BULLET][COLOR_WARNING_TEXT][ICON_HAPPINESS_4] Unhappiness Modifier (Difference): {1_Num}%[ENDCOLOR]</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_WLTKD">
+			<Text>[NEWLINE][ICON_BULLET]We Love the King Day Modifier (Difference): {1_Num}%</Text>
+		</Replace>
 	</Language_en_US>
 </GameData>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_en_US.xml
@@ -3325,7 +3325,8 @@
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_BAZAAR_HELP">
 			<Text>
-				[ICON_BULLET]Land trade routes originating from this city have a 20% increase in range. 
+				[ICON_BULLET]+2 [ICON_PEACE] Faith.
+				[NEWLINE][ICON_BULLET]Land trade routes originating from this city have a 20% increase in range. 
 				[NEWLINE][ICON_BULLET]+2 [ICON_GOLD] Gold for every [ICON_RES_OIL] Oil and Oasis worked by this city.
 				[NEWLINE][ICON_BULLET]Land International Trade Route from this city produces +6 [ICON_GOLD] Base Gold.
 			</Text>
@@ -8420,7 +8421,7 @@
 		</Replace>
 
 		<Replace Tag="TXT_KEY_POLICY_LIGHTNING_WARFARE_HELP" >
-			<Text>[COLOR_POSITIVE_TEXT]Lightning Warfare[ENDCOLOR][NEWLINE]+2 [ICON_MOVES] Movement for Great Generals.  +1 [ICON_MOVES] Movement for All Land Non-militia Units. The use of roads in enemy territory is permitted.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Lightning Warfare[ENDCOLOR][NEWLINE]+2 [ICON_MOVES] Movement for Great Generals. +1 [ICON_MOVES] Movement for All Land Non-militia Units. The use of roads in enemy territory is permitted.</Text>
 		</Replace>
 
 		<Replace Tag="TXT_KEY_POLICY_TOTAL_WAR_HELP" >
@@ -10392,7 +10393,7 @@
 		<Replace Tag="TXT_KEY_TRAIT_ART_OF_WAR">
 			<Text>
 			[ICON_BULLET]All Land Units can earn points toward a [ICON_GOLDEN_AGE] Golden Age for each enemy killed (50% of its [ICON_STRENGTH] Combat Strength).
-			[NEWLINE][ICON_BULLET]In the Golden Age, the [ICON_CITIZEN] population growth of all cities requires -20% food, the [ICON_RESEARCH] increase in Research expenditures from the number of cities -80%.
+			[NEWLINE][ICON_BULLET]In the Golden Age, the [ICON_CITIZEN] population growth of all cities requires -20% food, halved the [ICON_RESEARCH] increase in Research expenditures from the number of cities.
 			</Text>
 		</Replace>
 
@@ -10403,7 +10404,7 @@
 			<Text>
 			China has entered a new [ICON_GOLDEN_AGE][COLOR_POSITIVE_TEXT]prosperity[ENDCOLOR]! 
 			[NEWLINE][NEWLINE]All gold-producing plots have an additional +1[ICON_GOLD] gold production, +20% national [ICON_PRODUCTION] production capacity, and [ICON_CULTURE] culture. 
-			[NEWLINE]The [ICON_CITIZEN] population growth of all cities requires -20% food, the increase in [ICON_RESEARCH] Research expenditure from the number of cities -80%.
+			[NEWLINE]The [ICON_CITIZEN] population growth of all cities requires -20% food, halved  the increase in [ICON_RESEARCH] Research expenditure from the number of cities.
 			</Text>
 		</Row>
 
@@ -10492,7 +10493,7 @@
 		</Replace>
 		<Replace Tag="TXT_KEY_TRAIT_BUFFALO_HORNS">
 			<Text>
-				[ICON_BULLET]-50% experience needed to earn their next promotion for all units and pay 15% less for land unit maintenance.
+				[ICON_BULLET]All units -50% experience needed to earn their next promotion and will not disband due to deficit.
 				[NEWLINE][ICON_BULLET]Each source of [ICON_RES_GOLD] Gold, [ICON_RES_SILVER] Silver and [ICON_RES_GEMS] Gems worked by Zulu Cities produces +5 [ICON_GOLD] Gold. 
 			</Text>
 		</Replace>
@@ -10615,7 +10616,6 @@
 			<Text>
 				[ICON_BULLET]Rivers and adjacent difficult terrain count as clear terrain for [ICON_MOVES] Movement. 
 				[NEWLINE][ICON_BULLET]Rivers extend length of land trade routes as if they were roads. 
-				[NEWLINE][ICON_BULLET]+1 [ICON_GOLD] Gold for every Trading Post.
 				[NEWLINE][ICON_BULLET]-200 Administrative cost for City onrivers.
 			</Text>
 		</Replace>
@@ -10678,8 +10678,8 @@
 
 		<Replace Tag="TXT_KEY_TRAIT_DIPLOMACY_GREAT_PEOPLE">
 			<Text>
-				[ICON_BULLET]When declaring friendship, Sweden and their friend gain a +10% boost to [ICON_GREAT_PEOPLE] Great Person generation and +10% of the other's [ICON_RESEARCH] research.
-				[NEWLINE][ICON_BULLET]Every 4 [ICON_CITIZEN] Citizens in Small Cities (6+ Population) provide +1 [ICON_RESEARCH] Science Output. 
+				[ICON_BULLET]Every 4 [ICON_CITIZEN] Citizens in Small Cities (6+ Population) provide +1 [ICON_RESEARCH] Science Output. 
+				[NEWLINE][ICON_BULLET]When declaring friendship, Sweden and their friend gain a +10% boost to [ICON_GREAT_PEOPLE] Great Person generation and +10% of the other's [ICON_RESEARCH] research.
 			</Text>
 		</Replace>
 		
@@ -11059,7 +11059,7 @@
 			<Text>Islamic Prophet</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_HELP">
-			<Text>Islamic Prophet is the unique prophet unit for Arabia. He can found or enhance a religion, construct the special Holy Site improvement and spread religion one more time than the normal prophet unit (5 times in total). He can also write Quran to generate one-time amount of [ICON_CULTURE] Culture like Great Writers, and even stronger(This ability would be available even if he has only 1 time to spread the religion).</Text>
+			<Text>Islamic Prophet is the unique prophet unit for Arabia. He can found or enhance a religion, construct the special Holy Site improvement and spread religion one more time than the normal prophet unit (5 times in total). He can also write Quran to generate one-time amount of [ICON_CULTURE] Culture like Great Writers(This ability would be available even if he has only 1 time to spread the religion).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_TEXT">
 			<Text>Prophets in Islam include "messengers", bringers of a divine revelation via an angel; and "prophets", lawbringers that Muslims believe were sent by God to every people, bringing God's message in a language they can understand. Belief in Islamic prophets is one of the six articles of the Islamic faith, and specifically mentioned in the Quran.</Text>
@@ -17208,7 +17208,7 @@
 			<Text>
 			[ICON_BULLET]Alternative to the amphitheater, cheaper to build.
 			[NEWLINE][ICON_BULLET]+15% training speed of [ICON_WAR]military units in this city.
-			[NEWLINE][ICON_BULLET]When a military unit is promoted, get a one-time [ICON_CULTURE]culture boost with half of Current Era (at least 1) from each Ithaca.
+			[NEWLINE][ICON_BULLET]When a military unit (Non-militia) is promoted, get a one-time [ICON_CULTURE]culture boost with half of Current Era (at least 1) from each Ithaca.
 			</Text>
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_ZULU_IZIKO_TEXT">
@@ -17529,8 +17529,9 @@
         </Row>
         <Row Tag="TXT_KEY_BUILDING_SWEDEN_NOBEL_PRIZE_HELP">
             <Text>
-                [ICON_BULLET] Requires only 26 people to build.
-                [NEWLINE][ICON_BULLET] When a great scientist is born in Sweden or an ally, it will bring one-time [ICON_RESEARCH] scientific research output to both parties, equivalent to 15% of the great scientist's current strength.
+				[ICON_BULLET]Scientists: +2 [ICON_RESEARCH] Science, -2 [ICON_GOLD] Gold for research funds.
+                [NEWLINE][ICON_BULLET]When a great scientist is born in Sweden or an ally, it will bring one-time [ICON_RESEARCH] scientific research output to both parties, equivalent to 20% of the great scientist's current strength.
+				[NEWLINE][NEWLINE]The cost goes up the more cities there are in the empire.
             </Text>
         </Row>
 		<Row Tag="TXT_KEY_YIELD_OVERFLOW">

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
@@ -885,7 +885,8 @@
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_BAZAAR_HELP">
 			<Text>
-				[ICON_BULLET]从本城市出发的陆地商队范围增加20%。
+				[ICON_BULLET]+2[ICON_PEACE]信仰。
+				[NEWLINE][ICON_BULLET]从本城市出发的陆地商队范围增加20%。
 				[NEWLINE][ICON_BULLET]本城每处[ICON_RES_OIL]石油和绿洲+2[ICON_GOLD]金钱产出。
 				[NEWLINE][ICON_BULLET]通向其他文明的陆地商路+6基础[ICON_GOLD]金钱。
 			</Text>
@@ -5831,7 +5832,7 @@
 		<Replace Tag="TXT_KEY_TRAIT_ART_OF_WAR">
 			<Text>
 				[ICON_BULLET]所有陆军单位都自带消灭敌人后，获得相当于敌单位战斗力数值50%的[ICON_GOLDEN_AGE]黄金时代点数的晋升。
-				[NEWLINE][ICON_BULLET]黄金时代中，所有城市的[ICON_CITIZEN]人口增长所需粮食-20%，来自城市数量的[ICON_RESEARCH]科研阈值-80%。
+				[NEWLINE][ICON_BULLET]黄金时代中，所有城市的[ICON_CITIZEN]人口增长所需粮食-20%，来自城市数量的[ICON_RESEARCH]科研阈值减半。
 			</Text>
 		</Replace>
 		<Row Tag="TXT_KEY_SP_UA_CHINA_GOLDENAGE_ANNOUNCE">
@@ -5841,7 +5842,7 @@
 			<Text>
 				中国进入了一个崭新的[ICON_GOLDEN_AGE][COLOR_POSITIVE_TEXT]盛世[ENDCOLOR]！
 				[NEWLINE][NEWLINE]所有金钱产出的地块额外+1[ICON_GOLD]金钱产出，全国+20%[ICON_PRODUCTION]产能，[ICON_CULTURE]文化。
-				[NEWLINE]所有城市的[ICON_CITIZEN]人口增长所需粮食-20%，来自城市数量的[ICON_RESEARCH]科研阈值-80%。
+				[NEWLINE]所有城市的[ICON_CITIZEN]人口增长所需粮食-20%，来自城市数量的[ICON_RESEARCH]科研阈值减半。
 			</Text>
 		</Row>
 
@@ -5934,7 +5935,7 @@
 
 		<Replace Tag="TXT_KEY_TRAIT_BUFFALO_HORNS">
 			<Text>
-				[ICON_BULLET]所有军事单位获得晋升所需经验值-50%，陆上单位维护费-15%。
+				[ICON_BULLET]所有军事单位获得晋升所需经验值-50%，且不会因为赤字被解散。
 				[NEWLINE][ICON_BULLET]境内有市民工作的每处[ICON_RES_GOLD]黄金、[ICON_RES_SILVER]白银和[ICON_RES_GEMS]宝石资源+5[ICON_GOLD]金钱。
 			</Text>
 		</Replace>
@@ -6056,7 +6057,6 @@
 			<Text>
 				[ICON_BULLET]河流及其相邻区块不会阻碍己方单位[ICON_MOVES]移动。
 				[NEWLINE][ICON_BULLET]陆地商路能够通过河流线延长（视为道路）。
-				[NEWLINE][ICON_BULLET]所有贸易站+1[ICON_GOLD]金钱产出。
 				[NEWLINE][ICON_BULLET]沿河城市减少200点离心倾向。
 			</Text>
 		</Replace>
@@ -6485,7 +6485,7 @@
 			<Text>伊斯兰先知</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_HELP">
-			<Text>伊斯兰先知是阿拉伯文明的特殊单位，替代大先知。该单位能够创建或强化宗教，建造圣地，传教5次（比普通大先知多一次）等，同时还可以消耗他一次性产出大量[ICON_CULTURE]文化（即使仅剩1次传教次数也可使用该能力，产出数值同大文学家）。</Text>
+			<Text>伊斯兰先知是阿拉伯文明的特殊单位，替代大先知。该单位能够创建或强化宗教，建造圣地，传教5次（比普通大先知多一次）等，同时还可以消耗他一次性产出大量[ICON_CULTURE]文化（即使仅剩1次传教次数也可使用该能力）。</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_TEXT">
 			<Text>穆斯林认为先知（阿拉伯语：نبي）是凡人，是真主派遣的。每位先知都带来了伊斯兰式的基本信息，包括独一造物主的信仰，避免偶像崇拜与罪恶。他们都向大众传播伊斯兰教，并告知将出现见证律法的最后先知，他是真主所派遣的最后使者：穆罕默德。他们都向不同人群传播同一个讯息，并教导互有细微差异的律法。这些细微差异构成了伊斯兰教，然而主流穆斯林不认为这些差异是伊斯兰教支离破碎的版本。伊斯兰传统认为真主向万国万邦派遣使者。在伊斯兰教里，惟独穆罕默德是真主派来教化全世界的使者，其他使者只向特定民族或国家宣教。[NEWLINE][NEWLINE]不像犹太教和基督教，伊斯兰教还区分了使者（rasul，رسول）和先知（nabi，نبی）。这两种身分都是真主启示的。不同的是，「使者」还带来了真主启示的经典。每位「使者」都是「先知」，但并不是每位「先知」都是「使者」。[NEWLINE][NEWLINE]穆斯林认为阿丹（亚当）是第一位先知，而穆罕默德则是最后一位；因此穆罕默德的头衔是「众先知的封印」。在伊斯兰教里，尔撒（耶稣）是先知（并非每个人都如此认为）也是使者，因为他接受真主的「启示」并带来了《引支勒》。穆斯林相信，真主派遣了超过124,000位使者，这在权威的圣训中就提及了。根据圣训记载，其中有五位使者是最劳苦功高的，他们分别是努哈（挪亚）、易卜拉欣（亚伯拉罕）、穆萨（摩西）、尔撒（耶稣）以及穆罕默德。 </Text>
@@ -15541,7 +15541,7 @@
 			<Text>
 				[ICON_BULLET]替代露天剧场，造价更低。
 				[NEWLINE][ICON_BULLET]本城[ICON_WAR]军事单位训练速度+15%。
-				[NEWLINE][ICON_BULLET]军事单位晋升时，每个伊扎卡使你获得当前时代/2的[ICON_CULTURE]文化（至少为1）。
+				[NEWLINE][ICON_BULLET]非民兵单位晋升时，每个伊扎卡使你获得当前时代/2的[ICON_CULTURE]文化（至少为1）。
 			</Text>
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_ZULU_IZIKO_TEXT">
@@ -15884,8 +15884,9 @@
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_SWEDEN_NOBEL_PRIZE_HELP">
 			<Text>
-				[ICON_BULLET]只需26人口即可建造。
-				[NEWLINE][ICON_BULLET]瑞典或盟友诞生一位大科学家时，为双方带来一次性[ICON_RESEARCH]科研产出，数值相当于该大科学家当前强度的15%。
+				[ICON_BULLET]科学家：+2[ICON_RESEARCH]科研，+2[ICON_GOLD]维护费。
+				[NEWLINE][ICON_BULLET]瑞典或盟友诞生一位大科学家时，为双方带来一次性[ICON_RESEARCH]科研产出，数值相当于该大科学家当前强度的20%。
+				[NEWLINE][NEWLINE]文明的城市数量越多建造成本越高。
 			</Text>
 		</Row>
 		<Row Tag="TXT_KEY_YIELD_OVERFLOW">

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_CN.xml
@@ -16654,5 +16654,21 @@
 		<Row Tag="TXT_KEY_MILITARY_PROMISE">
 			<Text>承诺撤军</Text>
 		</Row>
+
+		<Replace Tag="TXT_KEY_FOODMOD_PLAYER">
+			<Text>[NEWLINE][ICON_BULLET]全文明修正（余粮）: {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_CAPITAL">
+			<Text>[NEWLINE][ICON_BULLET][ICON_CAPITAL]首都修正（余粮）: {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_RELIGION">
+			<Text>[NEWLINE][ICON_BULLET]宗教信条修正（余粮）: {1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_UNHAPPY">
+			<Text>[NEWLINE][ICON_BULLET][COLOR_WARNING_TEXT][ICON_HAPPINESS_4]不满修正（余粮）: {1_Num}%[ENDCOLOR]</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_WLTKD">
+			<Text>[NEWLINE][ICON_BULLET]我们爱领袖日修正（余粮）: {1_Num}%</Text>
+		</Replace>
 	</Language_zh_CN>
 </GameData>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
@@ -16463,5 +16463,21 @@
 		<Row Tag="TXT_KEY_MILITARY_PROMISE">
 			<Text>承諾撤軍</Text>
 		</Row>
+
+		<Replace Tag="TXT_KEY_FOODMOD_PLAYER">
+			<Text>[NEWLINE][ICON_BULLET]帝國修正值（余糧）：{1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_CAPITAL">
+			<Text>[NEWLINE][ICON_BULLET][ICON_CAPITAL]首都修正值（余糧）：{1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_RELIGION">
+			<Text>[NEWLINE][ICON_BULLET]宗教信條修正值（余糧）：{1_Num}%</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_UNHAPPY">
+			<Text>[NEWLINE][ICON_BULLET][COLOR_WARNING_TEXT][ICON_HAPPINESS_4]不滿度修正值（余糧）：{1_Num}%[ENDCOLOR]</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_FOODMOD_WLTKD">
+			<Text>[NEWLINE][ICON_BULLET]王之日修正值（余糧）：{1_Num}%</Text>
+		</Replace>
 	</Language_zh_Hant_HK>
 </GameData>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Localization/TextInfos_zh_Hant_HK.xml
@@ -859,7 +859,8 @@
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_BAZAAR_HELP">
 			<Text>
-				[ICON_BULLET]從本城市出發的陸地商隊範圍增加20%。
+				[ICON_BULLET]+2[ICON_PEACE]信仰。
+				[NEWLINE][ICON_BULLET]從本城市出發的陸地商隊範圍增加20%。
 				[NEWLINE][ICON_BULLET]本城每處[ICON_RES_OIL]石油和綠洲+2[ICON_GOLD]金幣產出。
 				[NEWLINE][ICON_BULLET]通向其他文明的陸地商路+6基礎[ICON_GOLD]金幣。
 			</Text>
@@ -5733,7 +5734,7 @@
 		<Replace Tag="TXT_KEY_TRAIT_ART_OF_WAR">
 			<Text>
 				[ICON_BULLET]所有陸軍單位都自帶消滅敵人後，獲得相當於敵單位戰鬥力數值50%的[ICON_GOLDEN_AGE]黃金時代點數的晉升。
-				[NEWLINE][ICON_BULLET]黃金時代中，所有城市的[ICON_CITIZEN]人口增長所需糧食-20%，來自城市數量的[ICON_RESEARCH]科研阈值-80%。
+				[NEWLINE][ICON_BULLET]黃金時代中，所有城市的[ICON_CITIZEN]人口增長所需糧食-20%，來自城市數量的[ICON_RESEARCH]科研阈值減半。
 			</Text>
 		</Replace>
 		<Row Tag="TXT_KEY_SP_UA_CHINA_GOLDENAGE_ANNOUNCE">
@@ -5743,7 +5744,7 @@
 			<Text>
 				中國進入了一個嶄新的[ICON_GOLDEN_AGE][COLOR_POSITIVE_TEXT]盛世[ENDCOLOR]！
 				[NEWLINE][NEWLINE]所有金錢產出的地塊額外+1[ICON_GOLD]金錢產出，全國+20%[ICON_PRODUCTION]產能，[ICON_CULTURE]文化。
-				[NEWLINE]所有城市的[ICON_CITIZEN]人口成長所需糧食-20%，來自城市數量的[ICON_RESEARCH]科研阈值-80%。
+				[NEWLINE]所有城市的[ICON_CITIZEN]人口成長所需糧食-20%，來自城市數量的[ICON_RESEARCH]科研阈值減半。
 			</Text>
 		</Row>
 
@@ -5836,7 +5837,7 @@
 
 		<Replace Tag="TXT_KEY_TRAIT_BUFFALO_HORNS">
 			<Text>
-				[ICON_BULLET]所有軍事單位獲得晉升所需經驗值-50%，陸上單位維護費-15%。
+				[ICON_BULLET]所有軍事單位獲得晉升所需經驗值-50%，且不會因爲赤字被解散。
 				[NEWLINE][ICON_BULLET]境內有市民工作的每處[ICON_RES_GOLD]黃金、[ICON_RES_SILVER]白銀和[ICON_RES_GEMS]寶石資源+5[ICON_GOLD]金錢。
 			</Text>
 		</Replace>
@@ -5957,7 +5958,6 @@
 			<Text>
 				[ICON_BULLET]河流及其相鄰區塊不會阻礙己方單位[ICON_MOVES]移動。
 				[NEWLINE][ICON_BULLET]陸地商路能夠通過河流線延長（視為道路）。
-				[NEWLINE][ICON_BULLET]所有貿易站+1[ICON_GOLD]金錢產出。
 				[NEWLINE][ICON_BULLET]沿河城市减少200点离心倾向。
 			</Text>
 		</Replace>
@@ -6385,7 +6385,7 @@
 			<Text>伊斯蘭先知</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_HELP">
-			<Text>伊斯蘭先知是阿拉伯文明的特殊單位，替代預言家。該單位能夠創建或強化宗教，建造聖地，傳教5次（比普通預言家多一次）等，同時還可以消耗他一次性產出大量[ICON_CULTURE]文化值（即使僅剩1次傳教次數也可使用該能力，產出數值同大文學家）。</Text>
+			<Text>伊斯蘭先知是阿拉伯文明的特殊單位，替代預言家。該單位能夠創建或強化宗教，建造聖地，傳教5次（比普通預言家多一次）等，同時還可以消耗他一次性產出大量[ICON_CULTURE]文化值（即使僅剩1次傳教次數也可使用該能力）。</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_ARABIAN_PROPHET_TEXT">
 			<Text>穆斯林認為先知（阿拉伯語：نبي）是凡人，是真主派遣的。每位先知都帶來了伊斯蘭式的基本信息，包括獨一造物主的信仰，避免偶像崇拜與罪惡。他們都向大眾傳播伊斯蘭教，並告知將出現見證律法的最後先知，他是真主所派遣的最後使者：穆罕默德。他們都向不同人群傳播同一個訊息，並教導互有細微差異的律法。這些細微差異構成了伊斯蘭教，然而主流穆斯林不認為這些差異是伊斯蘭教支離破碎的版本。伊斯蘭傳統認為真主向萬國萬邦派遣使者。在伊斯蘭教裡，惟獨穆罕默德是真主派來教化全世界的使者，其他使者只向特定民族或國家宣教。[NEWLINE][NEWLINE]不像猶太教和基督教，伊斯蘭教還區分了使者（rasul，رسول）和先知（nabi，نبی）。這兩種身分都是真主啟示的。不同的是，「使者」還帶來了真主啟示的經典。每位「使者」都是「先知」，但並不是每位「先知」都是「使者」。[NEWLINE][NEWLINE]穆斯林認為阿丹（亞當）是第一位先知，而穆罕默德則是最後一位；因此穆罕默德的頭銜是「眾先知的封印」。在伊斯蘭教裡，爾撒（耶穌）是先知（並非每個人都如此認為）也是使者，因為他接受真主的「啟示」並帶來了《引支勒》。穆斯林相信，真主派遣了超過124,000位使者，這在權威的聖訓中就提及了。根據聖訓記載，其中有五位使者是最勞苦功高的，他們分別是努哈（挪亞）、易蔔拉欣（亞伯拉罕）、穆薩（摩西）、爾撒（耶穌）以及穆罕默德。 </Text>
@@ -15358,7 +15358,7 @@
 			<Text>
 				[ICON_BULLET]替代露天劇場，造價更低。
 				[NEWLINE][ICON_BULLET]本城[ICON_WAR]軍事單位訓練速度+15%。
-				[NEWLINE][ICON_BULLET]軍事單位晉升時，每個伊紮卡使你獲得當前時代/2的[ICON_CULTURE]文化（至少為1）。
+				[NEWLINE][ICON_BULLET]非民兵單位晉升時，每個伊紮卡使你獲得當前時代/2的[ICON_CULTURE]文化（至少為1）。
 			</Text>
 		</Replace>
 		<Replace Tag="TXT_KEY_BUILDING_ZULU_IZIKO_TEXT">
@@ -15692,8 +15692,9 @@
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_SWEDEN_NOBEL_PRIZE_HELP">
 			<Text>
-				[ICON_BULLET]只需26人口即可建造。
-				[NEWLINE][ICON_BULLET]瑞典或盟友誕生一位大科學家時，為雙方帶來一次性[ICON_RESEARCH]科研產出，數值相當於該大科學家當前強度的15%。
+				[ICON_BULLET]科學家：+2[ICON_RESEARCH]科技值，+2[ICON_GOLD]維護費。
+				[NEWLINE][ICON_BULLET]瑞典或盟友誕生一位大科學家時，為雙方帶來一次性[ICON_RESEARCH]科研產出，數值相當於該大科學家當前強度的20%。
+				[NEWLINE][NEWLINE]文明的城市數量越多建造成本越高。
 			</Text>
 		</Row>
 		<Row Tag="TXT_KEY_YIELD_OVERFLOW">

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Civilian.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Civilian.xml
@@ -545,8 +545,6 @@
 			<Type>UNIT_ARABIAN_PROPHET</Type>
 			<Cost>-1</Cost>
 			<Moves>4</Moves>
-			<!--<BaseGold>1000</BaseGold>
-			<NumGoldPerEra>400</NumGoldPerEra>-->
 			<BaseCultureTurnsToCount>4</BaseCultureTurnsToCount>
 			<Capture>UNITCLASS_PROPHET</Capture>
 			<CivilianAttackPriority>CIVILIAN_ATTACK_PRIORITY_HIGH</CivilianAttackPriority>

--- a/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Naval.xml
+++ b/Super Power - Remaking of World Order (v 7)/Gameplay/XML/Units/Units_Naval.xml
@@ -1074,7 +1074,7 @@
 			<BaseSightRange>2</BaseSightRange>
 			<Combat>160</Combat>
 			<RangedCombat>120</RangedCombat>
-			<Cost>380</Cost>
+			<Cost>450</Cost>
 			<Moves>6</Moves>
 			<Range>3</Range>
 			<HurryCostModifier>50</HurryCostModifier>
@@ -1102,7 +1102,7 @@
 			<PortraitIndex>24</PortraitIndex>
 			<MoveRate>WOODEN_BOAT</MoveRate>
 			<ProjectPrereq>PROJECT_NAVAL_EXPLORATION</ProjectPrereq>
-			<ExtraMaintenanceCost>22</ExtraMaintenanceCost>
+			<ExtraMaintenanceCost>24</ExtraMaintenanceCost>
 		</Row>
 		<Row>
 			<Class>UNITCLASS_SHIP_OF_THE_LINE</Class>
@@ -1111,7 +1111,7 @@
 			<BaseSightRange>2</BaseSightRange>
 			<Combat>140</Combat>
 			<RangedCombat>80</RangedCombat>
-			<Cost>450</Cost>
+			<Cost>360</Cost>
 			<Moves>8</Moves>
 			<Range>3</Range>
 			<HurryCostModifier>50</HurryCostModifier>
@@ -1139,7 +1139,7 @@
 			<PortraitIndex>2</PortraitIndex>
 			<MoveRate>WOODEN_BOAT</MoveRate>
 			<ProjectPrereq>PROJECT_NAVAL_EXPLORATION</ProjectPrereq>
-			<ExtraMaintenanceCost>24</ExtraMaintenanceCost>
+			<ExtraMaintenanceCost>18</ExtraMaintenanceCost>
 		</Row>
 
 

--- a/Super Power - Remaking of World Order (v 7)/Super Power - Remaking of World Order (v 7).civ5proj
+++ b/Super Power - Remaking of World Order (v 7)/Super Power - Remaking of World Order (v 7).civ5proj
@@ -533,7 +533,7 @@ Some Imgaes and Visual Elements are from the game: ACE Combat (published by Namc
         <Type>Mod</Type>
         <Name>(1)CIV5MPDLL</Name>
         <Id>a2969a0a-e4da-41cc-9e0b-19b29aa971d8</Id>
-        <MinVersion>48</MinVersion>
+        <MinVersion>50</MinVersion>
         <MaxVersion>999</MaxVersion>
       </Association>
     </ModDependencies>


### PR DESCRIPTION
1.所有余粮加成都将标注：（余粮），并统一繁体该类加成文本
2.中国：UA黄金时代来自城市数量的科研阈值(消除->减半)
3.瑞典：UB诺贝尔奖需要40人口才能建造，科研基数15%->20%
4.暹罗：UB经院删除基础3信仰
5.阿拉伯：UB巴扎补上增加信仰产出的描述
6.祖鲁：
a)	UA维护费减免由于接口无效删除，新增单位不会因为赤字被解散
b)	UB伊扎卡不再对民兵生效
7.英国：UU主力舰不再减少花费和维护费
8.桑海：
a)	UA删除对贸易站加成
b)	UU远征舰队花费降低450->360，维护费降低24->18
9.AI时代赠送更改移民回滚